### PR TITLE
Add process path to Windows process structure

### DIFF
--- a/src/memcore.nim
+++ b/src/memcore.nim
@@ -36,6 +36,7 @@ type
     debug: bool
     base: uint
     when defined(windows):
+      path: string
       handle: HANDLE
 
   Module = object
@@ -139,8 +140,9 @@ proc getProcessPath(process: Process): string {.exportpy: "get_process_path".} =
     discard readlink(fmt"/proc/{process.pid}/exe".cstring, path.cstring, maxPath)
     path.strip()
   elif defined(windows):
-    var path = newSeq[WCHAR](maxPath)
-    GetModuleFileNameEx(process.handle, 0, path[0].addr, maxPath)
+    var path: array[maxPath + 1, WCHAR]
+    let size = (toInt(sizeof(path) / sizeof(path[0]))).int32
+    discard QueryFullProcessImageNameW(process.handle, 0, path[0].addr, size.addr)
     nullTerminated($$path)
 
 iterator enumModules(process: Process): Module {.exportpy: "enum_modules"} =
@@ -222,6 +224,7 @@ proc openProcess(process: PyObject, debug: bool = false): Process {.exportpy: "o
 
   when defined(windows):
     result.handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, sPid.DWORD)
+    result.path = getProcessPath(result)
     if result.handle == FALSE:
       raise newException(Exception, fmt"Unable to open Process [Pid: {sPid}] {getErrorStr()}")
 

--- a/src/memcore.nim
+++ b/src/memcore.nim
@@ -36,7 +36,6 @@ type
     debug: bool
     base: uint
     when defined(windows):
-      path: string
       handle: HANDLE
 
   Module = object
@@ -226,7 +225,6 @@ proc openProcess(process: PyObject, debug: bool = false): Process {.exportpy: "o
     result.handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, sPid.DWORD)
     if result.handle == FALSE:
       raise newException(Exception, fmt"Unable to open Process [Pid: {sPid}] {getErrorStr()}")
-    result.path = getProcessPath(result)
 
 proc closeProcess(process: Process) {.exportpy: "close_process".} =
   when defined(windows):

--- a/src/memcore.nim
+++ b/src/memcore.nim
@@ -224,9 +224,9 @@ proc openProcess(process: PyObject, debug: bool = false): Process {.exportpy: "o
 
   when defined(windows):
     result.handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, sPid.DWORD)
-    result.path = getProcessPath(result)
     if result.handle == FALSE:
       raise newException(Exception, fmt"Unable to open Process [Pid: {sPid}] {getErrorStr()}")
+    result.path = getProcessPath(result)
 
 proc closeProcess(process: Process) {.exportpy: "close_process".} =
   when defined(windows):


### PR DESCRIPTION
The code has been updated to include the process path in the Windows process structure. This was achieved by modifying the process initialization section of the Windows code block. Since im unsure if the Linux part of it works, I just added it to Windows.